### PR TITLE
Format help output

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -10,7 +10,10 @@ int main(int argc, const char* argv[])
   if (argc == 2 && strcmp(argv[1], "--help") == 0)
   {
     printf("Usage: wren [file] [arguments...]\n");
-    printf("  --help  Show command line usage\n");
+    printf("\n");
+    printf("Optional arguments:\n");
+    printf("  --help     Show command line usage\n");
+    printf("  --version  Show version\n");
     return 0;
   }
 


### PR DESCRIPTION
Add missing `--version` option to optional arguments listing.

### Before

```
$ wren --help
Usage: wren [file] [arguments...]
  --help  Show command line usage
```

### After

```
$ wren --help
Usage: wren [file] [arguments...]

Optional arguments:
  --help     Show command line usage
  --version  Show version
```