### PR TITLE
Parse CLI arguments using `ketopt`

### DIFF
--- a/deps/klib/ketopt.h
+++ b/deps/klib/ketopt.h
@@ -1,0 +1,120 @@
+#ifndef KETOPT_H
+#define KETOPT_H
+
+#include <string.h> /* for strchr() and strncmp() */
+
+#define ko_no_argument       0
+#define ko_required_argument 1
+#define ko_optional_argument 2
+
+typedef struct {
+	int ind;   /* equivalent to optind */
+	int opt;   /* equivalent to optopt */
+	char *arg; /* equivalent to optarg */
+	int longidx; /* index of a long option; or -1 if short */
+	/* private variables not intended for external uses */
+	int i, pos, n_args;
+} ketopt_t;
+
+typedef struct {
+	char *name;
+	int has_arg;
+	int val;
+} ko_longopt_t;
+
+static ketopt_t KETOPT_INIT = { 1, 0, 0, -1, 1, 0, 0 };
+
+static void ketopt_permute(char *argv[], int j, int n) /* move argv[j] over n elements to the left */
+{
+	int k;
+	char *p = argv[j];
+	for (k = 0; k < n; ++k)
+		argv[j - k] = argv[j - k - 1];
+	argv[j - k] = p;
+}
+
+/**
+ * Parse command-line options and arguments
+ *
+ * This fuction has a similar interface to GNU's getopt_long(). Each call
+ * parses one option and returns the option name.  s->arg points to the option
+ * argument if present. The function returns -1 when all command-line arguments
+ * are parsed. In this case, s->ind is the index of the first non-option
+ * argument.
+ *
+ * @param s         status; shall be initialized to KETOPT_INIT on the first call
+ * @param argc      length of argv[]
+ * @param argv      list of command-line arguments; argv[0] is ignored
+ * @param permute   non-zero to move options ahead of non-option arguments
+ * @param ostr      option string
+ * @param longopts  long options
+ *
+ * @return ASCII for a short option; ko_longopt_t::val for a long option; -1 if
+ *         argv[] is fully processed; '?' for an unknown option or an ambiguous
+ *         long option; ':' if an option argument is missing
+ */
+static int ketopt(ketopt_t *s, int argc, char *argv[], int permute, const char *ostr, const ko_longopt_t *longopts)
+{
+	int opt = -1, i0, j;
+	if (permute) {
+		while (s->i < argc && (argv[s->i][0] != '-' || argv[s->i][1] == '\0'))
+			++s->i, ++s->n_args;
+	}
+	s->arg = 0, s->longidx = -1, i0 = s->i;
+	if (s->i >= argc || argv[s->i][0] != '-' || argv[s->i][1] == '\0') {
+		s->ind = s->i - s->n_args;
+		return -1;
+	}
+	if (argv[s->i][0] == '-' && argv[s->i][1] == '-') { /* "--" or a long option */
+		if (argv[s->i][2] == '\0') { /* a bare "--" */
+			ketopt_permute(argv, s->i, s->n_args);
+			++s->i, s->ind = s->i - s->n_args;
+			return -1;
+		}
+		s->opt = 0, opt = '?', s->pos = -1;
+		if (longopts) { /* parse long options */
+			int k, n_exact = 0, n_partial = 0;
+			const ko_longopt_t *o = 0, *o_exact = 0, *o_partial = 0;
+			for (j = 2; argv[s->i][j] != '\0' && argv[s->i][j] != '='; ++j) {} /* find the end of the option name */
+			for (k = 0; longopts[k].name != 0; ++k)
+				if (strncmp(&argv[s->i][2], longopts[k].name, j - 2) == 0) {
+					if (longopts[k].name[j - 2] == 0) ++n_exact, o_exact = &longopts[k];
+					else ++n_partial, o_partial = &longopts[k];
+				}
+			if (n_exact > 1 || (n_exact == 0 && n_partial > 1)) return '?';
+			o = n_exact == 1? o_exact : n_partial == 1? o_partial : 0;
+			if (o) {
+				s->opt = opt = o->val, s->longidx = o - longopts;
+				if (argv[s->i][j] == '=') s->arg = &argv[s->i][j + 1];
+				if (o->has_arg == 1 && argv[s->i][j] == '\0') {
+					if (s->i < argc - 1) s->arg = argv[++s->i];
+					else opt = ':'; /* missing option argument */
+				}
+			}
+		}
+	} else { /* a short option */
+		const char *p;
+		if (s->pos == 0) s->pos = 1;
+		opt = s->opt = argv[s->i][s->pos++];
+		p = strchr((char*)ostr, opt);
+		if (p == 0) {
+			opt = '?'; /* unknown option */
+		} else if (p[1] == ':') {
+			if (argv[s->i][s->pos] == 0) {
+				if (s->i < argc - 1) s->arg = argv[++s->i];
+				else opt = ':'; /* missing option argument */
+			} else s->arg = &argv[s->i][s->pos];
+			s->pos = -1;
+		}
+	}
+	if (s->pos < 0 || argv[s->i][s->pos] == 0) {
+		++s->i, s->pos = 0;
+		if (s->n_args > 0) /* permute */
+			for (j = i0; j < s->i; ++j)
+				ketopt_permute(argv, j, s->n_args);
+	}
+	s->ind = s->i - s->n_args;
+	return opt;
+}
+
+#endif

--- a/projects/make.bsd/wren_cli.make
+++ b/projects/make.bsd/wren_cli.make
@@ -19,7 +19,7 @@ endif
 # #############################################
 
 RESCOMP = windres
-INCLUDES += -I../../src/cli -I../../src/module -I../../deps/wren/include -I../../deps/wren/src/vm -I../../deps/wren/src/optional -I../../deps/libuv/include -I../../deps/libuv/src
+INCLUDES += -I../../src/cli -I../../src/module -I../../deps/wren/include -I../../deps/wren/src/vm -I../../deps/wren/src/optional -I../../deps/libuv/include -I../../deps/libuv/src -I../../deps/klib
 FORCE_INCLUDE +=
 ALL_CPPFLAGS += $(CPPFLAGS) -MMD -MP $(DEFINES) $(INCLUDES)
 ALL_RESFLAGS += $(RESFLAGS) $(DEFINES) $(INCLUDES)
@@ -87,8 +87,6 @@ ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g
 ALL_LDFLAGS += $(LDFLAGS)
 
-else
-  $(error "invalid configuration $(config)")
 endif
 
 # Per File Configurations
@@ -98,8 +96,61 @@ endif
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
+GENERATED += $(OBJDIR)/async.o
+GENERATED += $(OBJDIR)/bsd-ifaddrs.o
+GENERATED += $(OBJDIR)/bsd-proctitle.o
+GENERATED += $(OBJDIR)/core.o
+GENERATED += $(OBJDIR)/dl.o
+GENERATED += $(OBJDIR)/freebsd.o
+GENERATED += $(OBJDIR)/fs-poll.o
+GENERATED += $(OBJDIR)/fs.o
+GENERATED += $(OBJDIR)/getaddrinfo.o
+GENERATED += $(OBJDIR)/getnameinfo.o
+GENERATED += $(OBJDIR)/idna.o
+GENERATED += $(OBJDIR)/inet.o
+GENERATED += $(OBJDIR)/io.o
+GENERATED += $(OBJDIR)/kqueue.o
+GENERATED += $(OBJDIR)/loop-watcher.o
+GENERATED += $(OBJDIR)/loop.o
+GENERATED += $(OBJDIR)/main.o
+GENERATED += $(OBJDIR)/modules.o
+GENERATED += $(OBJDIR)/os.o
+GENERATED += $(OBJDIR)/path.o
+GENERATED += $(OBJDIR)/pipe.o
+GENERATED += $(OBJDIR)/poll.o
+GENERATED += $(OBJDIR)/posix-hrtime.o
+GENERATED += $(OBJDIR)/process.o
+GENERATED += $(OBJDIR)/random-devurandom.o
+GENERATED += $(OBJDIR)/random-getrandom.o
+GENERATED += $(OBJDIR)/random.o
+GENERATED += $(OBJDIR)/repl.o
+GENERATED += $(OBJDIR)/scheduler.o
+GENERATED += $(OBJDIR)/signal.o
+GENERATED += $(OBJDIR)/stream.o
+GENERATED += $(OBJDIR)/strscpy.o
+GENERATED += $(OBJDIR)/tcp.o
+GENERATED += $(OBJDIR)/thread.o
+GENERATED += $(OBJDIR)/threadpool.o
+GENERATED += $(OBJDIR)/timer.o
+GENERATED += $(OBJDIR)/timer1.o
+GENERATED += $(OBJDIR)/tty.o
+GENERATED += $(OBJDIR)/udp.o
+GENERATED += $(OBJDIR)/uv-common.o
+GENERATED += $(OBJDIR)/uv-data-getter-setters.o
+GENERATED += $(OBJDIR)/version.o
+GENERATED += $(OBJDIR)/vm.o
+GENERATED += $(OBJDIR)/wren_compiler.o
+GENERATED += $(OBJDIR)/wren_core.o
+GENERATED += $(OBJDIR)/wren_debug.o
+GENERATED += $(OBJDIR)/wren_opt_meta.o
+GENERATED += $(OBJDIR)/wren_opt_random.o
+GENERATED += $(OBJDIR)/wren_primitive.o
+GENERATED += $(OBJDIR)/wren_utils.o
+GENERATED += $(OBJDIR)/wren_value.o
+GENERATED += $(OBJDIR)/wren_vm.o
 OBJECTS += $(OBJDIR)/async.o
 OBJECTS += $(OBJDIR)/bsd-ifaddrs.o
 OBJECTS += $(OBJDIR)/bsd-proctitle.o
@@ -159,7 +210,7 @@ OBJECTS += $(OBJDIR)/wren_vm.o
 all: $(TARGET)
 	@:
 
-$(TARGET): $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
+$(TARGET): $(GENERATED) $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
 	$(PRELINKCMDS)
 	@echo Linking wren_cli
 	$(SILENT) $(LINKCMD)
@@ -185,9 +236,11 @@ clean:
 	@echo Cleaning wren_cli
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) rm -f  $(TARGET)
+	$(SILENT) rm -rf $(GENERATED)
 	$(SILENT) rm -rf $(OBJDIR)
 else
 	$(SILENT) if exist $(subst /,\\,$(TARGET)) del $(subst /,\\,$(TARGET))
+	$(SILENT) if exist $(subst /,\\,$(GENERATED)) rmdir /s /q $(subst /,\\,$(GENERATED))
 	$(SILENT) if exist $(subst /,\\,$(OBJDIR)) rmdir /s /q $(subst /,\\,$(OBJDIR))
 endif
 

--- a/projects/make.mac/wren_cli.make
+++ b/projects/make.mac/wren_cli.make
@@ -27,7 +27,7 @@ endif
 ifeq ($(origin AR), default)
   AR = ar
 endif
-INCLUDES += -I../../src/cli -I../../src/module -I../../deps/wren/include -I../../deps/wren/src/vm -I../../deps/wren/src/optional -I../../deps/libuv/include -I../../deps/libuv/src
+INCLUDES += -I../../src/cli -I../../src/module -I../../deps/wren/include -I../../deps/wren/src/vm -I../../deps/wren/src/optional -I../../deps/libuv/include -I../../deps/libuv/src -I../../deps/klib
 FORCE_INCLUDE +=
 ALL_CPPFLAGS += $(CPPFLAGS) -MMD -MP $(DEFINES) $(INCLUDES)
 ALL_RESFLAGS += $(RESFLAGS) $(DEFINES) $(INCLUDES)
@@ -95,8 +95,6 @@ ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g
 ALL_LDFLAGS += $(LDFLAGS)
 
-else
-  $(error "invalid configuration $(config)")
 endif
 
 # Per File Configurations
@@ -106,8 +104,62 @@ endif
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
+GENERATED += $(OBJDIR)/async.o
+GENERATED += $(OBJDIR)/bsd-ifaddrs.o
+GENERATED += $(OBJDIR)/core.o
+GENERATED += $(OBJDIR)/darwin-proctitle.o
+GENERATED += $(OBJDIR)/darwin.o
+GENERATED += $(OBJDIR)/dl.o
+GENERATED += $(OBJDIR)/fs-poll.o
+GENERATED += $(OBJDIR)/fs.o
+GENERATED += $(OBJDIR)/fsevents.o
+GENERATED += $(OBJDIR)/getaddrinfo.o
+GENERATED += $(OBJDIR)/getnameinfo.o
+GENERATED += $(OBJDIR)/idna.o
+GENERATED += $(OBJDIR)/inet.o
+GENERATED += $(OBJDIR)/io.o
+GENERATED += $(OBJDIR)/kqueue.o
+GENERATED += $(OBJDIR)/loop-watcher.o
+GENERATED += $(OBJDIR)/loop.o
+GENERATED += $(OBJDIR)/main.o
+GENERATED += $(OBJDIR)/modules.o
+GENERATED += $(OBJDIR)/os.o
+GENERATED += $(OBJDIR)/path.o
+GENERATED += $(OBJDIR)/pipe.o
+GENERATED += $(OBJDIR)/poll.o
+GENERATED += $(OBJDIR)/process.o
+GENERATED += $(OBJDIR)/proctitle.o
+GENERATED += $(OBJDIR)/random-devurandom.o
+GENERATED += $(OBJDIR)/random-getentropy.o
+GENERATED += $(OBJDIR)/random.o
+GENERATED += $(OBJDIR)/repl.o
+GENERATED += $(OBJDIR)/scheduler.o
+GENERATED += $(OBJDIR)/signal.o
+GENERATED += $(OBJDIR)/stream.o
+GENERATED += $(OBJDIR)/strscpy.o
+GENERATED += $(OBJDIR)/tcp.o
+GENERATED += $(OBJDIR)/thread.o
+GENERATED += $(OBJDIR)/threadpool.o
+GENERATED += $(OBJDIR)/timer.o
+GENERATED += $(OBJDIR)/timer1.o
+GENERATED += $(OBJDIR)/tty.o
+GENERATED += $(OBJDIR)/udp.o
+GENERATED += $(OBJDIR)/uv-common.o
+GENERATED += $(OBJDIR)/uv-data-getter-setters.o
+GENERATED += $(OBJDIR)/version.o
+GENERATED += $(OBJDIR)/vm.o
+GENERATED += $(OBJDIR)/wren_compiler.o
+GENERATED += $(OBJDIR)/wren_core.o
+GENERATED += $(OBJDIR)/wren_debug.o
+GENERATED += $(OBJDIR)/wren_opt_meta.o
+GENERATED += $(OBJDIR)/wren_opt_random.o
+GENERATED += $(OBJDIR)/wren_primitive.o
+GENERATED += $(OBJDIR)/wren_utils.o
+GENERATED += $(OBJDIR)/wren_value.o
+GENERATED += $(OBJDIR)/wren_vm.o
 OBJECTS += $(OBJDIR)/async.o
 OBJECTS += $(OBJDIR)/bsd-ifaddrs.o
 OBJECTS += $(OBJDIR)/core.o
@@ -168,7 +220,7 @@ OBJECTS += $(OBJDIR)/wren_vm.o
 all: $(TARGET)
 	@:
 
-$(TARGET): $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
+$(TARGET): $(GENERATED) $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
 	$(PRELINKCMDS)
 	@echo Linking wren_cli
 	$(SILENT) $(LINKCMD)
@@ -194,9 +246,11 @@ clean:
 	@echo Cleaning wren_cli
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) rm -f  $(TARGET)
+	$(SILENT) rm -rf $(GENERATED)
 	$(SILENT) rm -rf $(OBJDIR)
 else
 	$(SILENT) if exist $(subst /,\\,$(TARGET)) del $(subst /,\\,$(TARGET))
+	$(SILENT) if exist $(subst /,\\,$(GENERATED)) rmdir /s /q $(subst /,\\,$(GENERATED))
 	$(SILENT) if exist $(subst /,\\,$(OBJDIR)) rmdir /s /q $(subst /,\\,$(OBJDIR))
 endif
 

--- a/projects/make/wren_cli.make
+++ b/projects/make/wren_cli.make
@@ -19,7 +19,7 @@ endif
 # #############################################
 
 RESCOMP = windres
-INCLUDES += -I../../src/cli -I../../src/module -I../../deps/wren/include -I../../deps/wren/src/vm -I../../deps/wren/src/optional -I../../deps/libuv/include -I../../deps/libuv/src
+INCLUDES += -I../../src/cli -I../../src/module -I../../deps/wren/include -I../../deps/wren/src/vm -I../../deps/wren/src/optional -I../../deps/libuv/include -I../../deps/libuv/src -I../../deps/klib
 FORCE_INCLUDE +=
 ALL_CPPFLAGS += $(CPPFLAGS) -MMD -MP $(DEFINES) $(INCLUDES)
 ALL_RESFLAGS += $(RESFLAGS) $(DEFINES) $(INCLUDES)
@@ -87,8 +87,6 @@ ALL_CFLAGS += $(CFLAGS) $(ALL_CPPFLAGS) -g -std=c99
 ALL_CXXFLAGS += $(CXXFLAGS) $(ALL_CPPFLAGS) -g
 ALL_LDFLAGS += $(LDFLAGS)
 
-else
-  $(error "invalid configuration $(config)")
 endif
 
 # Per File Configurations
@@ -98,8 +96,63 @@ endif
 # File sets
 # #############################################
 
+GENERATED :=
 OBJECTS :=
 
+GENERATED += $(OBJDIR)/async.o
+GENERATED += $(OBJDIR)/core.o
+GENERATED += $(OBJDIR)/dl.o
+GENERATED += $(OBJDIR)/fs-poll.o
+GENERATED += $(OBJDIR)/fs.o
+GENERATED += $(OBJDIR)/getaddrinfo.o
+GENERATED += $(OBJDIR)/getnameinfo.o
+GENERATED += $(OBJDIR)/idna.o
+GENERATED += $(OBJDIR)/inet.o
+GENERATED += $(OBJDIR)/io.o
+GENERATED += $(OBJDIR)/linux-core.o
+GENERATED += $(OBJDIR)/linux-inotify.o
+GENERATED += $(OBJDIR)/linux-syscalls.o
+GENERATED += $(OBJDIR)/loop-watcher.o
+GENERATED += $(OBJDIR)/loop.o
+GENERATED += $(OBJDIR)/main.o
+GENERATED += $(OBJDIR)/modules.o
+GENERATED += $(OBJDIR)/os.o
+GENERATED += $(OBJDIR)/path.o
+GENERATED += $(OBJDIR)/pipe.o
+GENERATED += $(OBJDIR)/poll.o
+GENERATED += $(OBJDIR)/process.o
+GENERATED += $(OBJDIR)/procfs-exepath.o
+GENERATED += $(OBJDIR)/proctitle.o
+GENERATED += $(OBJDIR)/random-devurandom.o
+GENERATED += $(OBJDIR)/random-getrandom.o
+GENERATED += $(OBJDIR)/random-sysctl-linux.o
+GENERATED += $(OBJDIR)/random.o
+GENERATED += $(OBJDIR)/repl.o
+GENERATED += $(OBJDIR)/scheduler.o
+GENERATED += $(OBJDIR)/signal.o
+GENERATED += $(OBJDIR)/stream.o
+GENERATED += $(OBJDIR)/strscpy.o
+GENERATED += $(OBJDIR)/sysinfo-loadavg.o
+GENERATED += $(OBJDIR)/tcp.o
+GENERATED += $(OBJDIR)/thread.o
+GENERATED += $(OBJDIR)/threadpool.o
+GENERATED += $(OBJDIR)/timer.o
+GENERATED += $(OBJDIR)/timer1.o
+GENERATED += $(OBJDIR)/tty.o
+GENERATED += $(OBJDIR)/udp.o
+GENERATED += $(OBJDIR)/uv-common.o
+GENERATED += $(OBJDIR)/uv-data-getter-setters.o
+GENERATED += $(OBJDIR)/version.o
+GENERATED += $(OBJDIR)/vm.o
+GENERATED += $(OBJDIR)/wren_compiler.o
+GENERATED += $(OBJDIR)/wren_core.o
+GENERATED += $(OBJDIR)/wren_debug.o
+GENERATED += $(OBJDIR)/wren_opt_meta.o
+GENERATED += $(OBJDIR)/wren_opt_random.o
+GENERATED += $(OBJDIR)/wren_primitive.o
+GENERATED += $(OBJDIR)/wren_utils.o
+GENERATED += $(OBJDIR)/wren_value.o
+GENERATED += $(OBJDIR)/wren_vm.o
 OBJECTS += $(OBJDIR)/async.o
 OBJECTS += $(OBJDIR)/core.o
 OBJECTS += $(OBJDIR)/dl.o
@@ -161,7 +214,7 @@ OBJECTS += $(OBJDIR)/wren_vm.o
 all: $(TARGET)
 	@:
 
-$(TARGET): $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
+$(TARGET): $(GENERATED) $(OBJECTS) $(LDDEPS) | $(TARGETDIR)
 	$(PRELINKCMDS)
 	@echo Linking wren_cli
 	$(SILENT) $(LINKCMD)
@@ -187,9 +240,11 @@ clean:
 	@echo Cleaning wren_cli
 ifeq (posix,$(SHELLTYPE))
 	$(SILENT) rm -f  $(TARGET)
+	$(SILENT) rm -rf $(GENERATED)
 	$(SILENT) rm -rf $(OBJDIR)
 else
 	$(SILENT) if exist $(subst /,\\,$(TARGET)) del $(subst /,\\,$(TARGET))
+	$(SILENT) if exist $(subst /,\\,$(GENERATED)) rmdir /s /q $(subst /,\\,$(GENERATED))
 	$(SILENT) if exist $(subst /,\\,$(OBJDIR)) rmdir /s /q $(subst /,\\,$(OBJDIR))
 endif
 

--- a/projects/premake/premake5.lua
+++ b/projects/premake/premake5.lua
@@ -87,6 +87,17 @@ project "wren_cli"
     "../../deps/libuv/src/*.h"
   }
 
+-- klib dependency
+
+  includedirs {
+    "../../deps/klib"
+  }
+
+  files {
+    "../../deps/libuv/klib/*.c",
+    "../../deps/libuv/klib/*.h"
+  }
+
   -- unix common files
   filter "system:not windows"
     files {

--- a/projects/vs2017/wren_cli.vcxproj
+++ b/projects/vs2017/wren_cli.vcxproj
@@ -55,7 +55,8 @@
     <IgnoreWarnCompileDuplicatedFilename>true</IgnoreWarnCompileDuplicatedFilename>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>wren_cli</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <LatestTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</LatestTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release 64bit|x64'" Label="Configuration">
@@ -163,7 +164,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>NDEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;..\..\deps\klib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -185,7 +186,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>NDEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;..\..\deps\klib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -207,7 +208,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>NDEBUG;WREN_NAN_TAGGING=0;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;..\..\deps\klib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -229,7 +230,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>DEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;..\..\deps\klib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
       <MinimalRebuild>false</MinimalRebuild>
@@ -248,7 +249,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>DEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;..\..\deps\klib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
       <MinimalRebuild>false</MinimalRebuild>
@@ -267,7 +268,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>DEBUG;WREN_NAN_TAGGING=0;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;..\..\deps\klib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
       <MinimalRebuild>false</MinimalRebuild>

--- a/projects/vs2019/wren-cli.sln
+++ b/projects/vs2019/wren-cli.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 16
+# Visual Studio Version 16
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "wren_cli", "wren_cli.vcxproj", "{F8A65189-E473-AC94-0D8D-9A3CF9B8E122}"
 EndProject
 Global

--- a/projects/vs2019/wren_cli.vcxproj
+++ b/projects/vs2019/wren_cli.vcxproj
@@ -163,7 +163,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>NDEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;..\..\deps\klib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -185,7 +185,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>NDEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;..\..\deps\klib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -207,7 +207,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>NDEBUG;WREN_NAN_TAGGING=0;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;..\..\deps\klib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -229,7 +229,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>DEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;..\..\deps\klib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
       <MinimalRebuild>false</MinimalRebuild>
@@ -248,7 +248,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>DEBUG;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;..\..\deps\klib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
       <MinimalRebuild>false</MinimalRebuild>
@@ -267,7 +267,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>DEBUG;WREN_NAN_TAGGING=0;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\cli;..\..\src\module;..\..\deps\wren\include;..\..\deps\wren\src\vm;..\..\deps\wren\src\optional;..\..\deps\libuv\include;..\..\deps\libuv\src;..\..\deps\klib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
       <MinimalRebuild>false</MinimalRebuild>

--- a/projects/xcode/wren_cli.xcodeproj/project.pbxproj
+++ b/projects/xcode/wren_cli.xcodeproj/project.pbxproj
@@ -532,6 +532,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INSTALL_PATH = /usr/local/bin;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_NAME = wren_cli_d;
 			};
 			name = Debug;
@@ -544,6 +545,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_DYNAMIC_NO_PIC = NO;
 				INSTALL_PATH = /usr/local/bin;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_NAME = wren_cli;
 			};
 			name = Release;
@@ -577,6 +579,7 @@
 					../../deps/wren/src/optional,
 					../../deps/libuv/include,
 					../../deps/libuv/src,
+					../../deps/klib,
 				);
 			};
 			name = Debug;
@@ -608,6 +611,7 @@
 					../../deps/wren/src/optional,
 					../../deps/libuv/include,
 					../../deps/libuv/src,
+					../../deps/klib,
 				);
 			};
 			name = Release;

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -38,13 +38,13 @@ int main(int argc, const char* argv[])
     if (c == '?' && opt.opt)
     {
       fprintf(stderr, "unknown option: -%c\n", opt.opt);
-      return 0;
+      return 64; // EX_USAGE.
     }
 
     if (c == '?')
     {
       fprintf(stderr, "unknown option: %s\n", argv[opt.ind - 1]);
-      return 0;
+      return 64; // EX_USAGE.
     }
   }
 

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -1,38 +1,63 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "ketopt.h"
 #include "os.h"
 #include "vm.h"
 #include "wren.h"
 
 int main(int argc, const char* argv[])
 {
-  if (argc == 2 && strcmp(argv[1], "--help") == 0)
-  {
-    printf("Usage: wren [file] [arguments...]\n");
-    printf("\n");
-    printf("Optional arguments:\n");
-    printf("  --help     Show command line usage\n");
-    printf("  --version  Show version\n");
-    return 0;
-  }
+  static char opts[] = "hv";
+  static ko_longopt_t longopts[] = {
+    { "help", ko_no_argument, 301 },
+    { "version", ko_no_argument, 302 },
+    { NULL, 0, 0 }
+  };
+  ketopt_t opt = KETOPT_INIT;
 
-  if (argc == 2 && strcmp(argv[1], "--version") == 0)
+  int c;
+  while ((c = ketopt(&opt, argc, (char**) argv, 1, opts, longopts)) >= 0)
   {
-    printf("wren %s\n", WREN_VERSION_STRING);
-    return 0;
+    if (c == 'h' || c == 301)
+    {
+      printf("usage: wren [file] [arguments...]\n");
+      printf("\n");
+      printf("optional arguments:\n");
+      printf("  -h, --help     Show command line usage\n");
+      printf("  -v, --version  Show version\n");
+      return 0;
+    }
+
+    if (c == 'v' || c == 302)
+    {
+      printf("wren %s\n", WREN_VERSION_STRING);
+      return 0;
+    }
+
+    if (c == '?' && opt.opt)
+    {
+      fprintf(stderr, "unknown option: -%c\n", opt.opt);
+      return 0;
+    }
+
+    if (c == '?')
+    {
+      fprintf(stderr, "unknown option: %s\n", argv[opt.ind - 1]);
+      return 0;
+    }
   }
 
   osSetArguments(argc, argv);
 
   WrenInterpretResult result;
-  if (argc == 1)
+  if (opt.ind >= argc)
   {
     result = runRepl();
   }
   else
   {
-    result = runFile(argv[1]);
+    result = runFile(argv[opt.ind]);
   }
 
   // Exit with an error code if the script failed.


### PR DESCRIPTION
Introduces [`klib`](https://github.com/attractivechaos/klib) dependency. (Only the `ketopt.h` file.)

Adding support for both long and short flags `-h` and `--help`.
This is the first step towards implementing #11