### PR TITLE
Support relative module imports

### DIFF
--- a/src/cli/vm.c
+++ b/src/cli/vm.c
@@ -146,7 +146,16 @@ static const char* resolveModule(WrenVM* vm, const char* importer,
   if (pathType(module) == PATH_TYPE_SIMPLE) return module;
   
   // Get the directory containing the importing module.
-  Path* path = pathNew(importer);
+  Path* path;
+  if (strcmp(importer, "repl") == 0)
+  {
+    path = pathNew(rootDirectory);
+    pathAppendChar(path, '/');
+  }
+  else
+  {
+    path = pathNew(importer);
+  }
   pathDirName(path);
   
   // Add the relative import path.
@@ -357,8 +366,15 @@ WrenInterpretResult runFile(const char* path)
 
 WrenInterpretResult runRepl()
 {
-  // This cast is safe since we don't try to free the string later.
-  rootDirectory = (char*)".";
+  char buffer[PATH_MAX * 4];
+  size_t length = sizeof(buffer);
+  if (uv_cwd(buffer, &length) != 0)
+  {
+    fprintf(stderr, "Could not get current working directory.\n");
+    exit(70); // EX_SOFTWARE.
+  }
+  rootDirectory = buffer;
+
   initVM();
 
   printf("\\\\/\"-\n");

--- a/test/module/relative_different_level/a/foo.wren
+++ b/test/module/relative_different_level/a/foo.wren
@@ -1,0 +1,5 @@
+// Import module relative to the current module.
+import "../bar" for Bar
+// expect: ran bar module
+
+System.print(Bar) // expect: from bar

--- a/test/module/relative_different_level/bar.wren
+++ b/test/module/relative_different_level/bar.wren
@@ -1,0 +1,3 @@
+// nontest
+var Bar = "from bar"
+System.print("ran bar module")

--- a/test/module/relative_same_level/bar.wren
+++ b/test/module/relative_same_level/bar.wren
@@ -1,0 +1,3 @@
+// nontest
+var Bar = "from bar"
+System.print("ran bar module")

--- a/test/module/relative_same_level/foo.wren
+++ b/test/module/relative_same_level/foo.wren
@@ -1,0 +1,5 @@
+// Import module relative to the current module.
+import "./bar" for Bar
+// expect: ran bar module
+
+System.print(Bar) // expect: from bar


### PR DESCRIPTION
Alters module resolution algorithm to support importing modules relative to the root directory. Root directory may be one of:
1. Current working directory if `wren` is running in a REPL mode
2. Parent directory of the invoked script 