### PR TITLE
Implement `Process.exePath`

### DIFF
--- a/src/cli/modules.c
+++ b/src/cli/modules.c
@@ -25,8 +25,9 @@ extern void fileWriteBytes(WrenVM* vm);
 extern void platformIsPosix(WrenVM* vm);
 extern void platformName(WrenVM* vm);
 extern void processAllArguments(WrenVM* vm);
-extern void processVersion(WrenVM* vm);
 extern void processCwd(WrenVM* vm);
+extern void processExePath(WrenVM* vm);
+extern void processVersion(WrenVM* vm);
 extern void statPath(WrenVM* vm);
 extern void statBlockCount(WrenVM* vm);
 extern void statBlockSize(WrenVM* vm);
@@ -167,8 +168,9 @@ static ModuleRegistry modules[] =
     END_CLASS
     CLASS(Process)
       STATIC_METHOD("allArguments", processAllArguments)
-      STATIC_METHOD("version", processVersion)
       STATIC_METHOD("cwd", processCwd)
+      STATIC_METHOD("exePath", processExePath)
+      STATIC_METHOD("version", processVersion)
     END_CLASS
   END_MODULE
   MODULE(repl)

--- a/src/module/os.c
+++ b/src/module/os.c
@@ -71,12 +71,6 @@ void processAllArguments(WrenVM* vm)
   }
 }
 
-
-void processVersion(WrenVM* vm) {
-  wrenEnsureSlots(vm, 1);
-  wrenSetSlotString(vm, 0, WREN_VERSION_STRING);
-}
-
 void processCwd(WrenVM* vm)
 {
   wrenEnsureSlots(vm, 1);
@@ -91,4 +85,26 @@ void processCwd(WrenVM* vm)
   }
 
   wrenSetSlotString(vm, 0, buffer);
+}
+
+void processExePath(WrenVM* vm)
+{
+  wrenEnsureSlots(vm, 1);
+
+  char buffer[WREN_PATH_MAX * 2 + 1];
+  size_t length = sizeof(buffer);
+  if (uv_exepath(buffer, &length) != 0)
+  {
+    wrenSetSlotString(vm, 0, "Cannot get the executable path.");
+    wrenAbortFiber(vm, 0);
+    return;
+  }
+
+  wrenSetSlotString(vm, 0, buffer);
+}
+
+void processVersion(WrenVM* vm) 
+{
+  wrenEnsureSlots(vm, 1);
+  wrenSetSlotString(vm, 0, WREN_VERSION_STRING);
 }

--- a/src/module/os.wren
+++ b/src/module/os.wren
@@ -10,6 +10,7 @@ class Process {
   static arguments { allArguments[2..-1] }
 
   foreign static allArguments
-  foreign static version
   foreign static cwd
+  foreign static exePath
+  foreign static version
 }

--- a/src/module/os.wren.inc
+++ b/src/module/os.wren.inc
@@ -12,6 +12,7 @@ static const char* osModuleSource =
 "  static arguments { allArguments[2..-1] }\n"
 "\n"
 "  foreign static allArguments\n"
-"  foreign static version\n"
 "  foreign static cwd\n"
+"  foreign static exePath\n"
+"  foreign static version\n"
 "}\n";

--- a/test/os/process/exe_path.wren
+++ b/test/os/process/exe_path.wren
@@ -1,0 +1,7 @@
+import "io" for File, Directory
+import "os" for Process
+
+System.print(Process.exePath is String) // expect: true
+System.print(!Process.exePath.isEmpty) // expect: true
+System.print(File.realPath(Process.exePath) == Process.exePath) // expect: true
+System.print(File.exists(Process.exePath)) // expect: true


### PR DESCRIPTION
Implement static getter `exePath` for the [`Process` class](http://wren.io/cli/modules/os/process.html).