### PR TITLE
Updated Process.arguments to only return slice if arg count >= 2

### DIFF
--- a/src/module/os.wren
+++ b/src/module/os.wren
@@ -7,7 +7,7 @@ class Platform {
 
 class Process {
   // TODO: This will need to be smarter when wren supports CLI options.
-  static arguments { allArguments[2..-1] }
+  static arguments { allArguments.count >= 2 ? allArguments[2..-1] : [] }
 
   foreign static allArguments
   foreign static version

--- a/src/module/os.wren.inc
+++ b/src/module/os.wren.inc
@@ -9,7 +9,7 @@ static const char* osModuleSource =
 "\n"
 "class Process {\n"
 "  // TODO: This will need to be smarter when wren supports CLI options.\n"
-"  static arguments { allArguments[2..-1] }\n"
+"  static arguments { allArguments.count >= 2 ? allArguments[2..-1] : [] }\n"
 "\n"
 "  foreign static allArguments\n"
 "  foreign static version\n"


### PR DESCRIPTION
When running _wren repl_ calling `Process.arguments` would return an error

**Before**

```
make $ ../../bin/wren_cli
\\/"-
 \_/   wren v0.3.0
> import "os" for Process
> Process.arguments
Runtime error: Range start out of bounds.
```

**After**

```
make $ ../../bin/wren_cli 
\\/"-
 \_/   wren v0.3.0
> import "os" for Process
> Process.arguments
[]
```