### PR TITLE
calls external commands

### DIFF
--- a/src/cli/modules.c
+++ b/src/cli/modules.c
@@ -27,6 +27,7 @@ extern void platformName(WrenVM* vm);
 extern void processAllArguments(WrenVM* vm);
 extern void processVersion(WrenVM* vm);
 extern void processCwd(WrenVM* vm);
+extern void processRunCommand(WrenVM* vm);
 extern void statPath(WrenVM* vm);
 extern void statBlockCount(WrenVM* vm);
 extern void statBlockSize(WrenVM* vm);
@@ -169,6 +170,7 @@ static ModuleRegistry modules[] =
       STATIC_METHOD("allArguments", processAllArguments)
       STATIC_METHOD("version", processVersion)
       STATIC_METHOD("cwd", processCwd)
+      STATIC_METHOD("runCommand_(_)", processRunCommand)
     END_CLASS
   END_MODULE
   MODULE(repl)

--- a/src/module/os.c
+++ b/src/module/os.c
@@ -18,7 +18,7 @@ void osSetArguments(int argc, const char* argv[])
 void platformName(WrenVM* vm)
 {
   wrenEnsureSlots(vm, 1);
-  
+
   #ifdef _WIN32
     wrenSetSlotString(vm, 0, "Windows");
   #elif __APPLE__
@@ -43,7 +43,7 @@ void platformName(WrenVM* vm)
 void platformIsPosix(WrenVM* vm)
 {
   wrenEnsureSlots(vm, 1);
-  
+
   #ifdef _WIN32
     wrenSetSlotBool(vm, 0, false);
   #elif __APPLE__
@@ -91,4 +91,10 @@ void processCwd(WrenVM* vm)
   }
 
   wrenSetSlotString(vm, 0, buffer);
+}
+
+void processRunCommand(WrenVM* vm)
+{
+  char* command = (char*)wrenGetSlotString(vm, 1);
+  system(command);
 }

--- a/src/module/os.wren
+++ b/src/module/os.wren
@@ -12,4 +12,9 @@ class Process {
   foreign static allArguments
   foreign static version
   foreign static cwd
+  static exec(command){
+    if(!(command is String)) Fiber.abort("Command must be a string")
+      runCommand_(command)
+    }
+  foreign static runCommand_(command)
 }

--- a/src/module/os.wren.inc
+++ b/src/module/os.wren.inc
@@ -14,4 +14,9 @@ static const char* osModuleSource =
 "  foreign static allArguments\n"
 "  foreign static version\n"
 "  foreign static cwd\n"
+"  static exec(command){\n"
+"    if(!(command is String)) Fiber.abort(\"Command must be a string\")\n"
+"    runCommand_(command)\n"
+"  }\n"
+"  foreign static runCommand_(command)\n"
 "}\n";


### PR DESCRIPTION
Added an `exec` command to the `Process` class that basically wraps C's `system()` function so now Wren-cli can call external programs.

Example:
```
import  "os" for Process

Process.exec("echo hello") // Should print hello to the console
Process.exec("not a command") // Errors out saying command not found
Process.exec(12) // Aborts current fiber saying that exec requires a string
``` 

Don't think this is a perfect implementation but it's minimal.