### PR TITLE
fix metrics and make a bit easier to read

### DIFF
--- a/util/metrics.py
+++ b/util/metrics.py
@@ -12,8 +12,8 @@ TODO_PATTERN = re.compile(r'\s*// TODO:')
 DOC_PATTERN = re.compile(r'\s*//')
 EXPECT_PATTERN = re.compile(r'// expect')
 
-C_FORMAT_LINE = "{0:<10}  {1:>7}  {2:>7}  {3:>7}  {4:>7}  {5:>7}  {6:>7}  {7:>7}"
-WREN_FORMAT_LINE = "{0:<10}  {1:>7}  {2:>7}  {3:>7}  {4:>7}  {5:>7}  {6:>7}"
+C_FORMAT_LINE = " {0:<10}  {1:>7}  {2:>7}  {3:>7}  {4:>7}  {5:>7}  {6:>7}  {7:>7}"
+WREN_FORMAT_LINE = " {0:<10}  {1:>7}  {2:>7}  {3:>7}  {4:>7}  {5:>7}  {6:>7}"
 
 num_files = 0
 num_docs = 0
@@ -115,17 +115,21 @@ def wren_metrics(label, directories):
       label, num_files, num_todos, num_code, num_expects, num_empty,
       num_todos + num_code + num_expects + num_empty))
 
+def hr(len=75):
+  print("-"*len)
 
 print(C_FORMAT_LINE.format(
-    "", "files", "';'", "todos", "code", "comment", "empty", "total"))
-c_metrics("vm",       ["src/vm", "src/include"])
-c_metrics("optional", ["src/optional"])
+    "C", "files", "';'", "todos", "code", "comment", "empty", "total"))
+hr()
+c_metrics("vm",       ["deps/wren/src/vm", "src/include"])
+c_metrics("optional", ["deps/wren/src/optional"])
 c_metrics("cli",      ["src/cli", "src/module"])
 
 print()
 print(WREN_FORMAT_LINE.format(
-    "", "files", "todos", "code", "expects", "empty", "total"))
-wren_metrics("core",      ["src/vm"])
-wren_metrics("optional",  ["src/optional"])
+    "WREN", "files", "todos", "code", "expects", "empty", "total"))
+hr(66)
+wren_metrics("core",      ["deps/wren/src/vm"])
+wren_metrics("optional",  ["deps/wren/src/optional"])
 wren_metrics("cli",       ["src/module"])
 wren_metrics("test",      ["test"])


### PR DESCRIPTION
Fixes the path locations for metrics and improves the
display just slightly while still keeping it minimal.

```
 C             files      ';'    todos     code  comment    empty    total
---------------------------------------------------------------------------
 vm               17     3637       21     5607     2225     3735    11588
 optional          4       87        1      148       20      109      278
 cli              17      678       20     1086      243      724     2073

 WREN          files    todos     code  expects    empty    total
------------------------------------------------------------------
 core              1        0      391        0       92      483
 optional          2        2      104        0       23      129
 cli               5       26     1081        0      210     1317
 test             92       14      370      203      274      861
```