### PR TITLE
fflush(0) before exiting cleanly

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -39,5 +39,8 @@ int main(int argc, const char* argv[])
   if (result == WREN_RESULT_COMPILE_ERROR) return 65; // EX_DATAERR.
   if (result == WREN_RESULT_RUNTIME_ERROR) return 70; // EX_SOFTWARE.
 
+  // flush all pipes before exiting
+  if (fflush(0)) { (void) fputs("Write error!\n", stderr); setExitCode(EXIT_FAILURE); }
+
   return getExitCode();
 }

--- a/src/cli/vm.c
+++ b/src/cli/vm.c
@@ -23,7 +23,7 @@ static char* rootDirectory = NULL;
 static Path* wrenModulesDirectory = NULL;
 
 // The exit code to use unless some other error overrides it.
-int defaultExitCode = 0;
+int defaultExitCode = EXIT_SUCCESS;
 
 // Reads the contents of the file at [path] and returns it as a heap allocated
 // string.


### PR DESCRIPTION
Resolves #56.

No idea how to write a test for this, but it's failure 
standard boilerplate I believe.

- Are EXIT_SUCCESS and EXIT_FAILURE defined on Windows platforms?