### PR TITLE
fix wren_to_string (allow files not ending in \n)

### DIFF
--- a/util/wren_to_c_string.py
+++ b/util/wren_to_c_string.py
@@ -21,11 +21,15 @@ static const char* {1}ModuleSource =
 
 def wren_to_c_string(input_path, wren_source_lines, module):
   wren_source = ""
+  # cut off blank lines at the bottom
+  while (wren_source_lines[-1].strip()==""):
+    wren_source_lines.pop()
   for line in wren_source_lines:
     line = line.replace('"', "\\\"")
-    line = line.replace("\n", "\\n\"")
-    if wren_source: wren_source += "\n"
-    wren_source += '"' + line
+    line = line.replace("\n", "\\n")
+    wren_source += '"' + line + '"\n'
+  
+  wren_source = wren_source.strip()
 
   return PREAMBLE.format(input_path, module, wren_source)
 


### PR DESCRIPTION
Fixes the `inc` builder to not care whether the wren
source files have a trailing line break or not.