### PR TITLE
Added Time class

### DIFF
--- a/src/cli/modules.c
+++ b/src/cli/modules.c
@@ -27,6 +27,7 @@ extern void platformName(WrenVM* vm);
 extern void processAllArguments(WrenVM* vm);
 extern void processVersion(WrenVM* vm);
 extern void processCwd(WrenVM* vm);
+extern void timeTime(WrenVM* vm);
 extern void statPath(WrenVM* vm);
 extern void statBlockCount(WrenVM* vm);
 extern void statBlockSize(WrenVM* vm);
@@ -169,6 +170,9 @@ static ModuleRegistry modules[] =
       STATIC_METHOD("allArguments", processAllArguments)
       STATIC_METHOD("version", processVersion)
       STATIC_METHOD("cwd", processCwd)
+    END_CLASS
+    CLASS(Time)
+      STATIC_METHOD("time", timeTime)
     END_CLASS
   END_MODULE
   MODULE(repl)

--- a/src/module/os.c
+++ b/src/module/os.c
@@ -1,6 +1,7 @@
 #include "os.h"
 #include "uv.h"
 #include "wren.h"
+#include <time.h>
 
 #if __APPLE__
   #include "TargetConditionals.h"
@@ -91,4 +92,9 @@ void processCwd(WrenVM* vm)
   }
 
   wrenSetSlotString(vm, 0, buffer);
+}
+
+void timeTime(WrenVM* vm) {
+  wrenEnsureSlots(vm, 1);
+  wrenSetSlotDouble(vm, 0, time(NULL));
 }

--- a/src/module/os.wren
+++ b/src/module/os.wren
@@ -13,3 +13,7 @@ class Process {
   foreign static version
   foreign static cwd
 }
+
+class Time {
+  foreign static time
+}

--- a/src/module/os.wren.inc
+++ b/src/module/os.wren.inc
@@ -14,4 +14,7 @@ static const char* osModuleSource =
 "  foreign static allArguments\n"
 "  foreign static version\n"
 "  foreign static cwd\n"
+"}\n"
+"class Time {\n"
+"  foreign static time\n"
 "}\n";

--- a/test/os/time/time.wren
+++ b/test/os/time/time.wren
@@ -1,0 +1,3 @@
+import "os" for Time
+
+System.print(Time.time > 0) // expect: true


### PR DESCRIPTION
A simple way of getting the current unix timestamp

```js
import "os" for Time

System.print(Time.time) // 1619555605

```

Related:

- https://github.com/wren-lang/wren/issues/812