### PR TITLE
(fix) remove only last extension

### DIFF
--- a/src/cli/path.c
+++ b/src/cli/path.c
@@ -161,6 +161,7 @@ void pathRemoveExtension(Path* path)
     {
       path->length = i;
       path->chars[path->length] = '\0';
+      return;
     }
   }
 }


### PR DESCRIPTION
Test case:

- ./hello_world.wren
- ./hello_world.spec.wren

The spec imports `hello_world` so that it can test it, but this
fails because they are both shortened to `hello_world` inside 
the CLI and this silently breaks the import for some reason.

I'm not sure if this is intentional or a bug but it seems the
wrong behavior to me.

Should this be enhanced to just remove `.wren` instead of just
removing the first extension it seens or is this adequate for 
now?