### PR TITLE
wren-cli: Fix build on glibc >= 2.34

### DIFF
--- a/src/cli/vm.c
+++ b/src/cli/vm.c
@@ -241,7 +241,7 @@ static WrenForeignClassMethods bindForeignClass(
   return methods;
 }
 
-static void doWrite(WrenVM* vm, const char* text)
+static void writeFn(WrenVM* vm, const char* text)
 {
   printf("%s", text);
 }
@@ -274,7 +274,7 @@ static void initVM()
   config.bindForeignClassFn = bindForeignClass;
   config.resolveModuleFn = resolveModule;
   config.loadModuleFn = loadModule;
-  config.writeFn = doWrite;
+  config.writeFn = writeFn;
   config.errorFn = reportError;
 
   // Since we're running in a standalone process, be generous with memory.

--- a/src/cli/vm.c
+++ b/src/cli/vm.c
@@ -241,7 +241,7 @@ static WrenForeignClassMethods bindForeignClass(
   return methods;
 }
 
-static void write(WrenVM* vm, const char* text)
+static void doWrite(WrenVM* vm, const char* text)
 {
   printf("%s", text);
 }
@@ -274,7 +274,7 @@ static void initVM()
   config.bindForeignClassFn = bindForeignClass;
   config.resolveModuleFn = resolveModule;
   config.loadModuleFn = loadModule;
-  config.writeFn = write;
+  config.writeFn = doWrite;
   config.errorFn = reportError;
 
   // Since we're running in a standalone process, be generous with memory.


### PR DESCRIPTION
Hi,
This patch fix https://github.com/wren-lang/wren/issues/1086. After glibc >= 2.34 for some configuration/systems, glibc includes new headers internally breaking our code.
Cheers