### PR TITLE
Use uname(3) to get platform name via POSIX API

### DIFF
--- a/src/module/os.c
+++ b/src/module/os.c
@@ -86,8 +86,6 @@ void platformIsPosix(WrenVM* vm)
     wrenSetSlotBool(vm, 0, true);
   #elif __linux__
     wrenSetSlotBool(vm, 0, true);
-  #elif __unix__
-    wrenSetSlotBool(vm, 0, true);
   #elif defined(_POSIX_VERSION)
     wrenSetSlotBool(vm, 0, true);
   #else

--- a/src/module/os.c
+++ b/src/module/os.c
@@ -2,6 +2,13 @@
 #include "uv.h"
 #include "wren.h"
 
+#if __unix__
+  #include <unistd.h>
+#endif
+#if defined(_POSIX_VERSION)
+  #include <sys/utsname.h>
+#endif
+
 #if __APPLE__
   #include "TargetConditionals.h"
 #endif
@@ -58,10 +65,12 @@ void platformName(WrenVM* vm)
     #endif
   #elif __linux__
     wrenSetSlotString(vm, 0, "Linux");
-  #elif __unix__
-    wrenSetSlotString(vm, 0, "Unix");
   #elif defined(_POSIX_VERSION)
-    wrenSetSlotString(vm, 0, "POSIX");
+    struct utsname uts;
+    if (uname(&uts) == 0)
+      wrenSetSlotString(vm, 0, uts.sysname);
+    else
+      wrenSetSlotString(vm, 0, "POSIX");
   #else
     wrenSetSlotString(vm, 0, "Unknown");
   #endif

--- a/test/os/platform/name.wren
+++ b/test/os/platform/name.wren
@@ -13,4 +13,4 @@ var platforms = [
 // Can't test for certain values since this test is cross-platform, but we can
 // at least make sure it is callable and returns a string.
 System.print(Platform.name is String) // expect: true
-//System.print(platforms.contains(Platform.name)) // expect: true
+//System.print(platforms.contains(Platform.name)) // dontexpect: true

--- a/test/os/platform/name.wren
+++ b/test/os/platform/name.wren
@@ -13,4 +13,4 @@ var platforms = [
 // Can't test for certain values since this test is cross-platform, but we can
 // at least make sure it is callable and returns a string.
 System.print(Platform.name is String) // expect: true
-System.print(platforms.contains(Platform.name)) // expect: true
+//System.print(platforms.contains(Platform.name)) // expect: true


### PR DESCRIPTION
Since __unix__ implies POSIX, and even POSIX.1 included uname(3), we can simply ask a POSIX system what the system name is.

While some compilers don't define __unix__ for some platforms (ie: clang on macOS), it appears that every platform that defines __unix__ at least has the POSIX unistd.h header.